### PR TITLE
Develop/2.x instagram filter

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" "5.0.0-rc.3"
+github "Alamofire/Alamofire" "5.0.0"
 github "kean/Nuke" ~> 8.4.0

--- a/Classes/PXLAlbumFilterOptions.swift
+++ b/Classes/PXLAlbumFilterOptions.swift
@@ -8,10 +8,39 @@
 
 import Foundation
 
-public struct PXLAlbumFilterOptions: Codable {
+public enum PXLContentSource {
+    case instagram_feed
+    case instagram_story
+    case twitter
+    case facebook
+    case api
+    case desktop
+    case email
+    var key: String {
+        switch self {
+        case .instagram_feed:
+            return "instagram_feed"
+        case .instagram_story:
+            return "instagram_story"
+        case .twitter:
+            return "twitter"
+        case .facebook:
+            return "facebook"
+        case .api:
+            return "api"
+        case .desktop:
+            return "desktop"
+        case .email:
+            return "email"
+        }
+    }
+}
+
+
+public struct PXLAlbumFilterOptions {
     public let minInstagramFollowers: Int?
     public let minTwitterFollowers: Int?
-    public let contentSource: [String]?
+    public let contentSource: [PXLContentSource]?
     public let contentType: [String]?
     public let inCategories: [Int]?
     public let filterBySubcaption: String?
@@ -81,7 +110,7 @@ public struct PXLAlbumFilterOptions: Codable {
 
     public init(minInstagramFollowers: Int? = nil,
                 minTwitterFollowers: Int? = nil,
-                contentSource: [String]? = nil,
+                contentSource: [PXLContentSource]? = nil,
                 contentType: [String]? = nil,
                 inCategories: [Int]? = nil,
                 filterBySubcaption: String? = nil,
@@ -199,7 +228,7 @@ public struct PXLAlbumFilterOptions: Codable {
                                      flagHasActionLink: flagHasActionLink)
     }
 
-    public func changeContentSource(newContentSource: [String]?) -> PXLAlbumFilterOptions {
+    public func changeContentSource(newContentSource: [PXLContentSource]?) -> PXLAlbumFilterOptions {
         return PXLAlbumFilterOptions(minInstagramFollowers: minInstagramFollowers,
                                      minTwitterFollowers: minTwitterFollowers,
                                      contentSource: newContentSource,
@@ -551,8 +580,19 @@ public struct PXLAlbumFilterOptions: Codable {
             options["has_action_link"] = hasActionLink
         }
 
-        if let contentSource = contentSource {
-            options["content_source"] = contentSource
+        if let contentSource = self.contentSource {
+            var array:[String] = []
+            var isInstagramAdded = false
+            for source in contentSource{
+                array.append(source.key)
+                if !isInstagramAdded &&
+                    (source.key=="instagram_feed" || source.key=="instagram_story") {
+                    isInstagramAdded = true
+                    array.append("instagram")
+                }
+            }
+            
+            options["content_source"] = array
         }
 
         if let contentType = self.contentType {

--- a/Classes/PXLAlbumFilterOptions.swift
+++ b/Classes/PXLAlbumFilterOptions.swift
@@ -8,36 +8,18 @@
 
 import Foundation
 
-public enum PXLContentSource {
-    case instagram_feed
-    case instagram_story
-    case twitter
-    case facebook
-    case api
-    case desktop
-    case email
-    var key: String {
-        switch self {
-        case .instagram_feed:
-            return "instagram_feed"
-        case .instagram_story:
-            return "instagram_story"
-        case .twitter:
-            return "twitter"
-        case .facebook:
-            return "facebook"
-        case .api:
-            return "api"
-        case .desktop:
-            return "desktop"
-        case .email:
-            return "email"
-        }
-    }
+public enum PXLContentSource :String, Codable{
+    case instagram_feed = "instagram_feed"
+    case instagram_story = "instagram_story"
+    case twitter = "twitter"
+    case facebook = "facebook"
+    case api = "api"
+    case desktop = "desktop"
+    case email = "email"
 }
 
 
-public struct PXLAlbumFilterOptions {
+public struct PXLAlbumFilterOptions :Codable{
     public let minInstagramFollowers: Int?
     public let minTwitterFollowers: Int?
     public let contentSource: [PXLContentSource]?
@@ -584,9 +566,9 @@ public struct PXLAlbumFilterOptions {
             var array:[String] = []
             var isInstagramAdded = false
             for source in contentSource{
-                array.append(source.key)
+                array.append(source.rawValue)
                 if !isInstagramAdded &&
-                    (source.key=="instagram_feed" || source.key=="instagram_story") {
+                    (source == PXLContentSource.instagram_feed || source == PXLContentSource.instagram_story) {
                     isInstagramAdded = true
                     array.append("instagram")
                 }

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -7,9 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2146AA63DEA854F748B84E2A /* Pods_ExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8DF01205A5126F0A0E4D097 /* Pods_ExampleTests.framework */; };
-		94C0640BECA3DF31E9641762 /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 642CA3B960C93EE246734429 /* Pods_Example.framework */; };
-		D8055AF6EAC69FBAD1A5E855 /* Pods_Example_ExampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 696F3B826D6EC765702835B7 /* Pods_Example_ExampleUITests.framework */; };
+		042EB2E76FAC9226D8B11A6E /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4CE72FFDFA73435F673FD4 /* Pods_Example.framework */; };
+		8226E89CFFCBBDFF753AEC6B /* Pods_Example_ExampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B7846117A9263BAE1A6F58A /* Pods_Example_ExampleUITests.framework */; };
 		F24D42F523C65BBE0091E324 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24D42F423C65BBE0091E324 /* AppDelegate.swift */; };
 		F24D42F723C65BBE0091E324 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24D42F623C65BBE0091E324 /* SceneDelegate.swift */; };
 		F24D42F923C65BBE0091E324 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24D42F823C65BBE0091E324 /* ViewController.swift */; };
@@ -18,6 +17,7 @@
 		F24D430123C65BBF0091E324 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F24D42FF23C65BBF0091E324 /* LaunchScreen.storyboard */; };
 		F24D430C23C65BC00091E324 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24D430B23C65BC00091E324 /* ExampleTests.swift */; };
 		F24D431723C65BC00091E324 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24D431623C65BC00091E324 /* ExampleUITests.swift */; };
+		F85F3150BB9DEF91E686FCBA /* Pods_ExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCE6AF1F69CB38DE855DB7E /* Pods_ExampleTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,12 +40,12 @@
 /* Begin PBXFileReference section */
 		09709C7B56523FEF6ADF2C49 /* Pods-ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-ExampleTests/Pods-ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		0E545E1A5E7B8ADBE31AF7FD /* Pods-ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleTests.release.xcconfig"; path = "Target Support Files/Pods-ExampleTests/Pods-ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		4A4CE72FFDFA73435F673FD4 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CA2236C7314A391A218AFB3 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
-		642CA3B960C93EE246734429 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		696F3B826D6EC765702835B7 /* Pods_Example_ExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_ExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5DCE6AF1F69CB38DE855DB7E /* Pods_ExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B44DCFD7ACC0F08BDE34329 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		8B7846117A9263BAE1A6F58A /* Pods_Example_ExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_ExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A014A7C4C477C418F331B7C8 /* Pods-Example-ExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-ExampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-Example-ExampleUITests/Pods-Example-ExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		D8DF01205A5126F0A0E4D097 /* Pods_ExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCAC9142E4ADF433F94D5960 /* Pods-Example-ExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-ExampleUITests.release.xcconfig"; path = "Target Support Files/Pods-Example-ExampleUITests/Pods-Example-ExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
 		F24D42F123C65BBE0091E324 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F24D42F423C65BBE0091E324 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -68,7 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				94C0640BECA3DF31E9641762 /* Pods_Example.framework in Frameworks */,
+				042EB2E76FAC9226D8B11A6E /* Pods_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,7 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2146AA63DEA854F748B84E2A /* Pods_ExampleTests.framework in Frameworks */,
+				F85F3150BB9DEF91E686FCBA /* Pods_ExampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -84,7 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8055AF6EAC69FBAD1A5E855 /* Pods_Example_ExampleUITests.framework in Frameworks */,
+				8226E89CFFCBBDFF753AEC6B /* Pods_Example_ExampleUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,9 +94,9 @@
 		21612BC36F3D954DFD54665D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				642CA3B960C93EE246734429 /* Pods_Example.framework */,
-				696F3B826D6EC765702835B7 /* Pods_Example_ExampleUITests.framework */,
-				D8DF01205A5126F0A0E4D097 /* Pods_ExampleTests.framework */,
+				4A4CE72FFDFA73435F673FD4 /* Pods_Example.framework */,
+				8B7846117A9263BAE1A6F58A /* Pods_Example_ExampleUITests.framework */,
+				5DCE6AF1F69CB38DE855DB7E /* Pods_ExampleTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -179,7 +179,7 @@
 				F24D42ED23C65BBE0091E324 /* Sources */,
 				F24D42EE23C65BBE0091E324 /* Frameworks */,
 				F24D42EF23C65BBE0091E324 /* Resources */,
-				9A51F088779DDFD0D2ADED32 /* [CP] Embed Pods Frameworks */,
+				CF7E130D9A1E80FB71BA68C3 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -217,7 +217,7 @@
 				F24D430E23C65BC00091E324 /* Sources */,
 				F24D430F23C65BC00091E324 /* Frameworks */,
 				F24D431023C65BC00091E324 /* Resources */,
-				753ECFDD2F9FE2B3D7B8561C /* [CP] Embed Pods Frameworks */,
+				6B314B2ED03C4962C50FF6B5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -344,7 +344,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		753ECFDD2F9FE2B3D7B8561C /* [CP] Embed Pods Frameworks */ = {
+		6B314B2ED03C4962C50FF6B5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -383,7 +383,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9A51F088779DDFD0D2ADED32 /* [CP] Embed Pods Frameworks */ = {
+		CF7E130D9A1E80FB71BA68C3 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -20,16 +20,14 @@ class ViewController: UIViewController {
         //        #warning In Environment Variables, replace with your Secret Key if you are making POST requests.
         PXLClient.sharedClient.secretKey = ProcessInfo.processInfo.environment["PIXLEE_SECRET_KEY"]
 
-        var filterOptions = PXLAlbumFilterOptions(minInstagramFollowers: 1, contentSource: [PXLContentSource.instagram_feed])
-//        let dateString = "20190101"
+        //        let dateString = "20190101"
 //        let dateFormatter = DateFormatter()
 //        dateFormatter.dateFormat = "yyyyMMdd"
 //        let date = dateFormatter.date(from: dateString)
-//
-//        filterOptions = filterOptions.changeSubmittedDateStart(newSubmittedDateStart: date)
-//
-//        PXLAlbumFilterOptions(submittedDateStart: date)
-        album.filterOptions = filterOptions
+        
+//        var filterOptions = PXLAlbumFilterOptions(minInstagramFollowers: 1, contentSource: [PXLContentSource.instagram_feed, PXLContentSource.instagram_story])
+//        album.filterOptions = filterOptions
+        
         album.sortOptions = PXLAlbumSortOptions(sortType: .popularity, ascending: false)
 
         // Where to get an albumId Pixlee? Visit here: https://app.pixlee.com/app#albums

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
         //        #warning In Environment Variables, replace with your Secret Key if you are making POST requests.
         PXLClient.sharedClient.secretKey = ProcessInfo.processInfo.environment["PIXLEE_SECRET_KEY"]
 
-//        var filterOptions = PXLAlbumFilterOptions(minInstagramFollowers: 1)
+        var filterOptions = PXLAlbumFilterOptions(minInstagramFollowers: 1, contentSource: [PXLContentSource.instagram_feed])
 //        let dateString = "20190101"
 //        let dateFormatter = DateFormatter()
 //        dateFormatter.dateFormat = "yyyyMMdd"
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
 //        filterOptions = filterOptions.changeSubmittedDateStart(newSubmittedDateStart: date)
 //
 //        PXLAlbumFilterOptions(submittedDateStart: date)
-//        album.filterOptions = filterOptions
+        album.filterOptions = filterOptions
         album.sortOptions = PXLAlbumSortOptions(sortType: .popularity, ascending: false)
 
         // Where to get an albumId Pixlee? Visit here: https://app.pixlee.com/app#albums

--- a/PixleeSDK.podspec
+++ b/PixleeSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "PixleeSDK"
-  spec.version      = "2.0.5"
+  spec.version      = "2.0.6"
   spec.summary      = "An API Wrapper for Pixlee API"
 
   spec.description      = "This SDK makes it easy for Pixlee customers to easily include Pixlee albums in their native iOS apps. It includes a native wrapper to the Pixlee album API as well as some drop-in and customizable UI elements to quickly get you started. This repo includes both the Pixlee iOS SDK and an example project to show you how it's used."
@@ -32,6 +32,6 @@ Pod::Spec.new do |spec|
   spec.source_files = 'Classes/**/*{swift}'
     
   spec.resources = "Classes/**/*.{png,jpeg,jpg,storyboard,xib,xcassets}"
-  spec.dependency 'Alamofire', '~> 5.0.0-rc.3'
+  spec.dependency 'Alamofire', '~> 5.0.0'
   spec.dependency 'Nuke', '~> 8.4.0'
 end


### PR DESCRIPTION
This is to reduce mistakes when using a "content_source" as either **instagram_feed** or **instagram_story**.

You cannot add **`instagram`** to "content_source" without one of **`instagram_feed`** and **`instagram_story`**. **`instagram_feed`** and **`instagram_story`** cannot be added to "content_source" without **`instagram`**. 

This update forces the app code to follow the rule otherwise the build cannot be succeeded.

https://developers.pixlee.com/reference#consuming-content
`
content_source (array of strings) - Media from a list of sources ("instagram", "twitter", "facebook", "api", "desktop", "email"). i.e. ["instagram", "twitter"].  SPECIAL NOTE: if "instagram" is included, one or both of the following strings must also be included: "instagram_feed", representing normal instagram content, and "instagram_story", representing story content.
`