### PR TITLE
instagram filter for SDK version 1.9.x

### DIFF
--- a/Classes/PXLAlbumFilterOptions.swift
+++ b/Classes/PXLAlbumFilterOptions.swift
@@ -8,10 +8,20 @@
 
 import Foundation
 
+public enum PXLContentSource :String, Codable{
+    case instagram_feed = "instagram_feed"
+    case instagram_story = "instagram_story"
+    case twitter = "twitter"
+    case facebook = "facebook"
+    case api = "api"
+    case desktop = "desktop"
+    case email = "email"
+}
+
 public struct PXLAlbumFilterOptions: Codable {
     public let minInstagramFollowers: Int?
     public let minTwitterFollowers: Int?
-    public let contentSource: [String]?
+    public let contentSource: [PXLContentSource]?
     public let contentType: [String]?
     public let inCategories: [Int]?
     public let filterBySubcaption: String?
@@ -81,7 +91,7 @@ public struct PXLAlbumFilterOptions: Codable {
 
     public init(minInstagramFollowers: Int? = nil,
                 minTwitterFollowers: Int? = nil,
-                contentSource: [String]? = nil,
+                contentSource: [PXLContentSource]? = nil,
                 contentType: [String]? = nil,
                 inCategories: [Int]? = nil,
                 filterBySubcaption: String? = nil,
@@ -199,7 +209,7 @@ public struct PXLAlbumFilterOptions: Codable {
                                      flagHasActionLink: flagHasActionLink)
     }
 
-    public func changeContentSource(newContentSource: [String]?) -> PXLAlbumFilterOptions {
+    public func changeContentSource(newContentSource: [PXLContentSource]?) -> PXLAlbumFilterOptions {
         return PXLAlbumFilterOptions(minInstagramFollowers: minInstagramFollowers,
                                      minTwitterFollowers: minTwitterFollowers,
                                      contentSource: newContentSource,
@@ -552,7 +562,18 @@ public struct PXLAlbumFilterOptions: Codable {
         }
 
         if let contentSource = contentSource {
-            options["content_source"] = contentSource
+            var array:[String] = []
+            var isInstagramAdded = false
+            for source in contentSource{
+                array.append(source.rawValue)
+                if !isInstagramAdded &&
+                    (source == PXLContentSource.instagram_feed || source == PXLContentSource.instagram_story) {
+                    isInstagramAdded = true
+                    array.append("instagram")
+                }
+            }
+            
+            options["content_source"] = array
         }
 
         if let contentType = self.contentType {

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -29,6 +29,7 @@ class ViewController: UIViewController {
 //        filterOptions = filterOptions.changeSubmittedDateStart(newSubmittedDateStart: date)
 //
 //        PXLAlbumFilterOptions(submittedDateStart: date)
+//        var filterOptions = PXLAlbumFilterOptions(minInstagramFollowers: 1, contentSource: [PXLContentSource.instagram_feed, PXLContentSource.instagram_story])
 //        album.filterOptions = filterOptions
         album.sortOptions = PXLAlbumSortOptions(sortType: .popularity, ascending: false)
 


### PR DESCRIPTION
This PR is to import https://github.com/pixlee/pixlee-ios-sdk/pull/14 into 1.9.x. 

For those who don't know the history of Alamofire library, this ios SDK has two branches for the release.
- release_1.9.x: supports Alamofire 4.9, AP Mall  only
- master: supports Alamofire 5.x

This approach is to avoid the dependency hell problem of Cocoapods. However, having two source code bases is not a good practice. If I figure out a solution that I can have one branch for the release supporting multiple library versions, I'll remove **release_1.9.x branch**.