### PR TITLE
Skip SecretKey check for analytics (version: 2.x)

### DIFF
--- a/Classes/PXLApiRequests.swift
+++ b/Classes/PXLApiRequests.swift
@@ -34,7 +34,7 @@ class PXLApiRequests {
         return ["API_KEY": apiKey]
     }
 
-    private func postHeaders(headers: [String: String], parameters: [String: Any]) -> [String: String] {
+    private func postHeaders(isDistilleryServer:Bool, headers: [String: String], parameters: [String: Any]) -> [String: String] {
         var httpHeaders = [String: String]()
 
         assert(apiKey != nil, "Your Pixlee API Key must be set before making API calls.")
@@ -44,7 +44,10 @@ class PXLApiRequests {
         httpHeaders["Content-Type"] = "application/json"
         httpHeaders["Accept"] = "application/json"
 
-        assert(secretKey != nil, "Your Pixlee Secret Key must be set before making API calls.")
+        if(isDistilleryServer) {
+            assert(secretKey != nil, "Your Pixlee Secret Key must be set before making API calls.")
+        }
+        
         if let secret = self.secretKey {
             if let parametersData = try? JSONSerialization.data(withJSONObject: newParameters, options: []), let jsonParameters = String(data: parametersData, encoding: String.Encoding.utf8) {
                 let cleanedJSON = jsonParameters.replacingOccurrences(of: "\\", with: "")
@@ -135,7 +138,7 @@ class PXLApiRequests {
 
         do {
             let parameters = defaultPostParameters().reduce(into: event.logParameters) { r, e in r[e.0] = e.1 }
-            let postHeaders = self.postHeaders(headers: [:], parameters: parameters)
+            let postHeaders = self.postHeaders(isDistilleryServer: false, headers: [:], parameters: parameters)
             let request = try urlRequest(.post, url, parameters: parameters, encoding: JSONEncoding.default, headers: postHeaders)
             return request
         } catch {
@@ -153,7 +156,7 @@ class PXLApiRequests {
 
                 let jsonString = String(data: jsonData, encoding: .utf8)!
 
-                let postHeaders = HTTPHeaders(self.postHeaders(headers: [:], parameters: parameters))
+                let postHeaders = HTTPHeaders(self.postHeaders(isDistilleryServer: true, headers: [:], parameters: parameters))
 
                 var url = url
                 url = url.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)!

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -630,7 +630,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = PXL.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -650,7 +650,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = PXL.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/PixleeSDK.podspec
+++ b/PixleeSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "PixleeSDK"
-  spec.version      = "2.2.0"
+  spec.version      = "2.2.1"
   spec.summary      = "An API Wrapper for Pixlee API"
 
   spec.description      = "This SDK makes it easy for Pixlee customers to easily include Pixlee albums in their native iOS apps. It includes a native wrapper to the Pixlee album API as well as some drop-in and customizable UI elements to quickly get you started. This repo includes both the Pixlee iOS SDK and an example project to show you how it's used."


### PR DESCRIPTION
This repo is for Alamofire 5.x, the latest.

This is to skip checking secret-key when firing Analytics. (We still keep checking secret-key when firing Distillery.)

This SDK used to check secret-key for all post calls. (Server: Distillery, Analytics) Analytics does not need secret-key, and Android SDK does not check secret-key for Analytics's post calls.

Therefore, in order to keep both SDK consistent, I removed the check for Analytics on this iOS SDK.

