### PR TITLE
Add the capability of reinitializing PXLClient in order to reload an album

### DIFF
--- a/Classes/PXLClient.swift
+++ b/Classes/PXLClient.swift
@@ -10,6 +10,7 @@ import Alamofire
 import Foundation
 
 public class PXLClient {
+    public init (){}
     public static var sharedClient = PXLClient()
 
     private let apiRequests = PXLApiRequests()

--- a/PixleeSDK.podspec
+++ b/PixleeSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "PixleeSDK"
-  spec.version      = "2.2.1"
+  spec.version      = "2.2.2"
   spec.summary      = "An API Wrapper for Pixlee API"
 
   spec.description      = "This SDK makes it easy for Pixlee customers to easily include Pixlee albums in their native iOS apps. It includes a native wrapper to the Pixlee album API as well as some drop-in and customizable UI elements to quickly get you started. This repo includes both the Pixlee iOS SDK and an example project to show you how it's used."


### PR DESCRIPTION
This is a hot-fix requested by AP Mall. I'll just merge and release it.

Based on the previous structure, refreshing an album is impossible. So, I added a feature that our client developers can refresh albums by reinitializing PXLClient which is used to fire API calls.