### PR TITLE
Fix a bug of showing wrong url by allocating nil(null) to ImageView

### DIFF
--- a/Classes/ViewControllers/PXLAlbumViewController/Cells/PXLAdvancedProductCell.swift
+++ b/Classes/ViewControllers/PXLAlbumViewController/Cells/PXLAdvancedProductCell.swift
@@ -62,6 +62,8 @@ class PXLAdvancedProductCell: UICollectionViewCell {
 
             if let imageUrl = viewModel.imageThumbUrl {
                 Nuke.loadImage(with: imageUrl, into: itemImageView)
+            }else{
+                itemImageView.image = nil
             }
 
             actionButton.setAttributedTitle(viewModel.attributedPrice, for: .normal)

--- a/Classes/ViewControllers/PXLAlbumViewController/Cells/PXLImageCell.swift
+++ b/Classes/ViewControllers/PXLAlbumViewController/Cells/PXLImageCell.swift
@@ -44,7 +44,10 @@ class PXLImageCell: UICollectionViewCell {
             NSLayoutConstraint.activate(gifConstraints)
             if let imageUrl = viewModel.photoUrl(for: .medium) {
                 Nuke.loadImage(with: imageUrl, into: gifView)
+            }else{
+                gifView.image = nil
             }
+            
             if let userName = viewModel.username {
                 authorLabel.text = "@\(userName)"
             }

--- a/Classes/ViewControllers/PXLAlbumViewController/Cells/PXLProductCell.swift
+++ b/Classes/ViewControllers/PXLAlbumViewController/Cells/PXLProductCell.swift
@@ -27,6 +27,8 @@ class PXLProductCell: UICollectionViewCell {
             
             if let imageUrl = viewModel.imageThumbUrl {
                 Nuke.loadImage(with: imageUrl, into: productImageView)
+            }else{
+                productImageView.image = nil
             }
 
             productActionButton.setTitle(viewModel.formattedPrice, for: .normal)

--- a/Classes/ViewControllers/PXLPhotoDetailsViewController/PXLPhotoDetailViewController.swift
+++ b/Classes/ViewControllers/PXLPhotoDetailsViewController/PXLPhotoDetailViewController.swift
@@ -69,6 +69,9 @@ public class PXLPhotoDetailViewController: UIViewController {
             if let imageUrl = viewModel.photoUrl(for: .medium) {
                 Nuke.loadImage(with: imageUrl, into: gifView)
                 Nuke.loadImage(with: imageUrl, into: backgroundImageView)
+            }else{
+                gifView.image = nil
+                backgroundImageView.image = nil
             }
             titleLabel.text = nil
 

--- a/Classes/Widgets/PXLPhotoProductView.swift
+++ b/Classes/Widgets/PXLPhotoProductView.swift
@@ -257,6 +257,9 @@ public class PXLPhotoProductView: UIViewController {
             if let imageUrl = viewModel.photoUrl(for: .medium) {
                 Nuke.loadImage(with: imageUrl, into: gifView)
                 Nuke.loadImage(with: imageUrl, into: backgroundImageView)
+            }else{
+                gifView.image = nil
+                backgroundImageView.image = nil
             }
 
             gifView.alpha = 1

--- a/Classes/Widgets/PXLPhotoView.swift
+++ b/Classes/Widgets/PXLPhotoView.swift
@@ -113,6 +113,9 @@ public class PXLPhotoView: UIView {
         if let imageUrl = photo.photoUrl(for: .medium) {
             Nuke.loadImage(with: imageUrl, into: gifView)
             Nuke.loadImage(with: imageUrl, into: backgroundImageView)
+        } else {
+            gifView.image = nil
+            backgroundImageView.image = nil
         }
         backgroundColor = UIColor.black.withAlphaComponent(0.2)
         if configuration.enableVideoPlayback, photo.isVideo, let videoURL = photo.videoUrl() {

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -668,7 +668,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6HRLMQGMGT;
+				DEVELOPMENT_TEAM = Q28M29YQL8;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -688,7 +688,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6HRLMQGMGT;
+				DEVELOPMENT_TEAM = Q28M29YQL8;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/PixleeSDK.podspec
+++ b/PixleeSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "PixleeSDK"
-  spec.version      = "2.4.0"
+  spec.version      = "2.4.1"
   spec.summary      = "An API Wrapper for Pixlee API"
 
   spec.description      = "This SDK makes it easy for Pixlee customers to easily include Pixlee albums in their native iOS apps. It includes a native wrapper to the Pixlee album API as well as some drop-in and customizable UI elements to quickly get you started. This repo includes both the Pixlee iOS SDK and an example project to show you how it's used."


### PR DESCRIPTION
ticket: https://pixlee.atlassian.net/browse/MAINT-7087

Since lists reuse their cells while scrolling, the codes playing the roles of setting up the UI should add `else if` and `else` cases when using `if`. when a nullable image url variable is nil(null), we should have made sure the ImageView to be empty. 

There's no code for that. I made that change.