### PR TITLE
[hotfix] Fixed a bug of not resuming video for version 2.5.1

### DIFF
--- a/Classes/Widgets/PXLPhotoProductView.swift
+++ b/Classes/Widgets/PXLPhotoProductView.swift
@@ -377,11 +377,16 @@ public class PXLPhotoProductView: UIViewController {
 
     override public func viewWillAppear(_ animated: Bool) {
         navigationController?.setNavigationBarHidden(true, animated: animated)
+        playVideo()
     }
 
     override public func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         print("PDPView.viewWillDisappear()")
+        stopVideo()
+    }
+    
+    public override func didReceiveMemoryWarning() {
         durationLabelUpdateTimer?.invalidate()
         destroyPlayer()
         do{

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		042EB2E76FAC9226D8B11A6E /* Pods_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4CE72FFDFA73435F673FD4 /* Pods_Example.framework */; };
+		5C03231025C8EB60006622F7 /* EmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C03230F25C8EB60006622F7 /* EmptyViewController.swift */; };
 		5C2D21AD25830CC1002EB673 /* PixleeCredentials.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5C2D21AC25830CC1002EB673 /* PixleeCredentials.plist */; };
 		5C8143412589D2AA00C1CC1A /* EmptyViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5C81433F2589D2AA00C1CC1A /* EmptyViewController.xib */; };
 		5C8143822589E99F00C1CC1A /* InfiniteScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8143812589E99F00C1CC1A /* InfiniteScrollViewController.swift */; };
@@ -62,6 +63,7 @@
 		09709C7B56523FEF6ADF2C49 /* Pods-ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-ExampleTests/Pods-ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		0E545E1A5E7B8ADBE31AF7FD /* Pods-ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleTests.release.xcconfig"; path = "Target Support Files/Pods-ExampleTests/Pods-ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		4A4CE72FFDFA73435F673FD4 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C03230F25C8EB60006622F7 /* EmptyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyViewController.swift; sourceTree = "<group>"; };
 		5C2D21AC25830CC1002EB673 /* PixleeCredentials.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = PixleeCredentials.plist; sourceTree = "<group>"; };
 		5C81433F2589D2AA00C1CC1A /* EmptyViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EmptyViewController.xib; sourceTree = "<group>"; };
 		5C8143812589E99F00C1CC1A /* InfiniteScrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollViewController.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				F23BA1AC25190384009FC402 /* PhotoProductListDemoViewController.swift */,
 				F23BA1AD25190384009FC402 /* PhotoProductListDemoViewController.xib */,
 				F296942D24224A86003EB9DD /* Cells */,
+				5C03230F25C8EB60006622F7 /* EmptyViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -507,6 +510,7 @@
 				5C8143902589F2AC00C1CC1A /* AutoPlayViewController.swift in Sources */,
 				5C8143A32589F60600C1CC1A /* GetPhotosViewController.swift in Sources */,
 				5C8143AB2589FC4400C1CC1A /* GetPhotoViewController.swift in Sources */,
+				5C03231025C8EB60006622F7 /* EmptyViewController.swift in Sources */,
 				5C8143822589E99F00C1CC1A /* InfiniteScrollViewController.swift in Sources */,
 				F2A8AC4A255E6F10008A40BF /* ListWithGifFileViewController.swift in Sources */,
 				F296942B242243BB003EB9DD /* WidgetsExampleViewController.swift in Sources */,

--- a/Example/Example/ViewControllers/EmptyViewController.swift
+++ b/Example/Example/ViewControllers/EmptyViewController.swift
@@ -1,0 +1,66 @@
+//
+//  EmptyViewController.swift
+//  Example
+//
+//  Created by Sungjun Hong on 2/2/21.
+//  Copyright © 2021 Pixlee. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class EmptyViewController: UIViewController {
+    static func getInstance(_ url: URL) -> EmptyViewController {
+        let vc = EmptyViewController(nibName: "EmptyViewController", bundle: Bundle.main)
+        vc.url = url
+        return vc
+    }
+    
+    var url: URL? = nil
+    let titleLabel = UILabel()
+    let bodyLabel = UILabel()
+    let button = UIButton()
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = UIColor.white
+        
+        button.setTitleColor(UIColor.blue, for: .normal)
+        button.setTitle("< Back", for: .normal)
+        button.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
+        view.addSubview(button)
+        
+        titleLabel.textColor = UIColor.black
+        titleLabel.text = "Product Detail"
+        titleLabel.textAlignment = .center
+        titleLabel.font = UIFont.boldSystemFont(ofSize: 20)
+        view.addSubview(titleLabel)
+        
+        bodyLabel.lineBreakMode = .byWordWrapping
+        bodyLabel.numberOfLines = 0
+        bodyLabel.textColor = UIColor.black
+        bodyLabel.text = "This is just an example of your product page. You need to implement this inside your app.\n\nClicked product url: \(url)"
+        bodyLabel.textAlignment = .center
+        bodyLabel.font = UIFont.boldSystemFont(ofSize: 15)
+        view.addSubview(bodyLabel)
+        
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        var yPosition = CGFloat(0)
+        if modalPresentationStyle.rawValue == 0 {
+            yPosition = CGFloat(view.window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0)
+        }
+        
+        button.frame = CGRect(x: 0, y: yPosition, width: 100, height: 50)
+        titleLabel.frame = CGRect(x:0, y: yPosition, width: view.frame.size.width, height: 50)
+        let padding = CGFloat(10)
+        bodyLabel.frame = CGRect(x:0 + padding, y: yPosition + 50 + padding, width: view.frame.size.width - (padding * 2), height: view.frame.size.height - (padding * 2))
+        
+    }
+    
+    @objc func buttonAction(sender: UIButton!) {
+        print("Back")
+        dismiss(animated: true, completion: nil)
+    }
+}

--- a/Example/Example/ViewControllers/PhotoProductListDemoViewController.swift
+++ b/Example/Example/ViewControllers/PhotoProductListDemoViewController.swift
@@ -81,6 +81,21 @@ extension PhotoProductListDemoViewController: PXLPhotoProductDelegate {
 
     public func shouldOpenURL(url: URL) -> Bool {
         print("url: \(url)")
+        let alert = UIAlertController(title: "Select a Modal Presentation Style.", message: "", preferredStyle: UIAlertController.Style.alert)
+        alert.addAction(UIAlertAction(title: "fullScreen", style: UIAlertAction.Style.default, handler: {_ in
+            let vc = EmptyViewController.getInstance(url)
+            vc.modalPresentationStyle = .fullScreen
+            self.present(vc, animated: true, completion: nil)
+            
+        }))
+        
+        alert.addAction(UIAlertAction(title: "popover", style: UIAlertAction.Style.default, handler: {_ in
+            let vc = EmptyViewController.getInstance(url)
+            self.present(vc, animated: true, completion: nil)
+            
+        }))
+        self.present(alert, animated: true, completion: nil)
+        
         return false
     }
 


### PR DESCRIPTION
Ticket: https://pixlee.atlassian.net/browse/MAINT-7324

Issue: If there is a 'fullscreen' view controller on top of the video player and the view controller is destroyed to come back to the player, the video player does not resume the video.

I added an example to the demo for checking the fix.

Since Stradivarius is using 2.5.1 version and wants a fix ASAP, this pr is to fix this bug on TAG 2.5.1 which will be merged to master_2.5.1.x branch I just created. 

I'm also adding this fix to previous versions in other PRs. 