### PR TITLE
Add CIRCLE_TAG

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,5 @@ commands:
       - run:
           name: deploy cooapods
           command:  |
-            export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
             pod lib lint --allow-warnings
             pod trunk push --allow-warnings

--- a/PixleeSDK.podspec
+++ b/PixleeSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "PixleeSDK"
-  spec.version      = ENV['LIB_VERSION'] || '1.0.0'
+  spec.version      = ENV['CIRCLE_TAG'] || '1.0.0'
   spec.summary      = "An API Wrapper for Pixlee API"
 
   spec.description      = "This SDK makes it easy for Pixlee customers to easily include Pixlee albums in their native iOS apps. It includes a native wrapper to the Pixlee album API as well as some drop-in and customizable UI elements to quickly get you started. This repo includes both the Pixlee iOS SDK and an example project to show you how it's used."


### PR DESCRIPTION
There was an issue with releasing hotfixes for lower versions. So, I added CIRCLE_TAG to read the correct tag. I tested this on another branch which works fine. You can have a look for the result.

a test branch: https://github.com/pixlee/PixleeTestCocoapods/releases
a deploy result for a lower version: https://app.circleci.com/pipelines/github/pixlee/PixleeTestCocoapods