### PR TITLE
[Hotfix] improvement of SKU and added square_medium_url

### DIFF
--- a/Classes/SDK/Converters/PXLPhotoConverter.swift
+++ b/Classes/SDK/Converters/PXLPhotoConverter.swift
@@ -86,6 +86,7 @@ class PXLPhotoConverter {
                         cdnSmallUrl: URL(string: dto.pixleeCDNPhotos.smallURL),
                         cdnMediumUrl: URL(string: dto.pixleeCDNPhotos.mediumURL),
                         cdnLargeUrl: URL(string: dto.pixleeCDNPhotos.largeURL),
-                        cdnOriginalUrl: URL(string: dto.pixleeCDNPhotos.originalURL))
+                        cdnOriginalUrl: URL(string: dto.pixleeCDNPhotos.originalURL),
+                        cdnSquareMediumUrl: URL(string: dto.pixleeCDNPhotos.squareMediumURL))
     }
 }

--- a/Classes/SDK/PXLAlbum.swift
+++ b/Classes/SDK/PXLAlbum.swift
@@ -13,7 +13,7 @@ public class PXLAlbum {
     public static let PXLAlbumDefaultPerPage: Int = 20
 
     public let identifier: String?
-    public let sku: Int?
+    public let sku: String?
 
     public var photos: [PXLPhoto]
     public var lastPageFetched: Int
@@ -43,7 +43,7 @@ public class PXLAlbum {
         hasNextPage = true
     }
 
-    public init(identifier: String? = nil, sku: Int? = nil, perPage: Int = PXLAlbum.PXLAlbumDefaultPerPage, photos: [PXLPhoto] = [PXLPhoto](), lastPageFetched: Int = 0, hasNextPage: Bool = true, sortOptions: PXLAlbumSortOptions? = nil, filterOptions: PXLAlbumFilterOptions? = nil) {
+    public init(identifier: String? = nil, sku: String? = nil, perPage: Int = PXLAlbum.PXLAlbumDefaultPerPage, photos: [PXLPhoto] = [PXLPhoto](), lastPageFetched: Int = 0, hasNextPage: Bool = true, sortOptions: PXLAlbumSortOptions? = nil, filterOptions: PXLAlbumFilterOptions? = nil) {
         self.identifier = identifier
         self.sku = sku
         self.perPage = perPage
@@ -65,7 +65,7 @@ public class PXLAlbum {
                         filterOptions: filterOptions)
     }
 
-    public func changeSKU(newSKU: Int) -> PXLAlbum {
+    public func changeSKU(newSKU: String) -> PXLAlbum {
         return PXLAlbum(identifier: identifier,
                         sku: newSKU,
                         perPage: PXLAlbum.PXLAlbumDefaultPerPage,

--- a/Classes/SDK/PXLClient.swift
+++ b/Classes/SDK/PXLClient.swift
@@ -124,7 +124,7 @@ public class PXLClient {
                     completionHandler?(nil, nil)
                     return nil
                 }
-            } else if let sku = album.identifier {
+            } else if let sku = album.sku {
                 var requestsForAlbum = loadingOperations[sku]
                 if requestsForAlbum == nil {
                     requestsForAlbum = [:]

--- a/Classes/SDK/PXLPhoto.swift
+++ b/Classes/SDK/PXLPhoto.swift
@@ -68,6 +68,7 @@ public struct PXLPhoto: Equatable {
     public let cdnMediumUrl: URL?
     public let cdnLargeUrl: URL?
     public let cdnOriginalUrl: URL?
+    public let cdnSquareMediumUrl: URL?
 
     public var coordinate: CLLocationCoordinate2D? {
         guard let latitude = self.latitude, let longitude = self.longitude else { return nil }


### PR DESCRIPTION
ticket: https://pixlee.atlassian.net/browse/IMP-644

Bug-fix
- gett content using SKU does not load the content. This is fixed now.

Change
- Change sku's primitive type from Int to String since sku can be any string

Added
- square_medium_url is added to PXLPhoto as Stradivarius requested.